### PR TITLE
Add a full VitePress docs site (#23)

### DIFF
--- a/.github/workflows/publish-to-github-pages.yaml
+++ b/.github/workflows/publish-to-github-pages.yaml
@@ -1,0 +1,59 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "**/*.md"
+      - ".vitepress/**"
+      - "index.js"
+      - "package*.json"
+      - "scripts/**"
+      - ".github/workflows/publish-to-github-pages.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  publish-to-github-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build site
+        run: npm run docs:build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ".vitepress/dist"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -1,0 +1,383 @@
+// Tell vitepress that `.html` is a known static-asset extension. Without
+// this, vitepress's client-side router intercepts `.html` link clicks,
+// strips the extension, and tries to load a `.md` page at the bare URL —
+// which 404s for browser-renderable HTML demos. With `html` in the known
+// set, `treatAsHtml(".html")` returns false, the click handler skips
+// intercept, and the browser does a normal same-tab navigation.
+process.env.VITE_EXTRA_EXTENSIONS ??= "html";
+
+import { defineConfig } from "vitepress";
+import { globSync } from "glob";
+// FIXME: gray-matter pulls in js-yaml 3.x, which carries a moderate advisory
+// (GHSA-h67p-54hq-rp68: quadratic-complexity DoS via repeated merge-key
+// aliases). The risk here is minimal: frontmatter is parsed at build time from
+// maintainer-authored files, never untrusted input. Watch for a maintained
+// gray-matter or a replacement parser and revisit then.
+import matter from "gray-matter";
+import {
+  readFileSync, writeFileSync, existsSync,
+} from "node:fs";
+import {
+  dirname, basename, posix,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+import { DOCS_BASE, repoPathToUrl } from "./url.js";
+import { renderForIndex, tokenize, processTerm } from "./search-helpers.js";
+import { generateNav, formatSegment } from "./nav.js";
+
+/**
+ * Build the breadcrumb trail shown above a page title, derived from the page's
+ * ancestor directories. For `guide/getting-started.md` the trail is a single
+ * `Guide` crumb; for `reference/errors/process-error.md` it is `Reference /
+ * Errors`. A directory that renders its own page (an `index.md`) links to its
+ * directory URL, using that page's frontmatter title as the label; a grouping
+ * directory with no `index.md` renders as plain text. The homepage and other
+ * top-level pages get no trail.
+ */
+function buildBreadcrumbs(relativePath) {
+  const parts = relativePath.split("/");
+  const fileName = parts[parts.length - 1];
+  let dirSegments = parts.slice(0, -1);
+  // An index.md renders at its directory URL, so the final directory segment is
+  // the page itself, not an ancestor — drop it.
+  if (fileName === "index.md") {
+    dirSegments = dirSegments.slice(0, -1);
+  }
+  if (dirSegments.length === 0) return [];
+
+  const crumbs = [];
+  let dir = "";
+  for (const segment of dirSegments) {
+    dir = dir ? `${dir}/${segment}` : segment;
+    const indexFile = `${dir}/index.md`;
+    let link = null;
+    let text = formatSegment(segment);
+    if (existsSync(indexFile)) {
+      link = `/${dir}/`;
+      try {
+        const { data } = matter(readFileSync(indexFile, "utf-8"));
+        if (data.title) text = data.title;
+      } catch {
+        // fall back to the formatted segment
+      }
+    }
+    crumbs.push({ text, link });
+  }
+  return crumbs;
+}
+
+/**
+ * Extensions the browser handles natively. For these, we emit the raw file at
+ * the native URL — no rendered viewer, no `.raw` alternate.
+ */
+const BROWSER_HANDLES = new Set([
+  "html", "htm",
+  "png", "jpg", "jpeg", "gif", "webp", "avif", "svg", "ico",
+  "pdf", "zip", "gz", "tar",
+  "mp3", "mp4", "wav", "ogg", "webm", "mov",
+  "ttf", "woff", "woff2", "otf",
+]);
+
+/**
+ * MIME types for the dev-mode middleware response. Production builds get
+ * Content-Type from the static host (GitHub Pages auto-detects).
+ */
+const MIME_TYPES = {
+  html: "text/html; charset=utf-8",
+  htm: "text/html; charset=utf-8",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  ico: "image/x-icon",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  gz: "application/gzip",
+  tar: "application/x-tar",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  ttf: "font/ttf",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  otf: "font/otf",
+};
+
+// Directories whose markdown is not part of the docs site — skip them when
+// scanning for linked assets, matching the nav/srcExclude carve-outs.
+const NON_DOC_GLOBS = [
+  "**/node_modules/**",
+  ".vitepress/**",
+  ".worktrees/**",
+  ".github/**",
+  "docs/**",
+  "specs/**",
+  "prompts/**",
+  "scripts/**",
+  "dist/**",
+];
+
+/**
+ * Discover non-markdown files linked from any markdown file in the source
+ * tree. Returns two buckets: `code` (renderable as a syntax-highlighted page)
+ * and `page` (browser handles directly). Targets that don't exist on disk are
+ * dropped silently — this isn't a link checker; vitepress already does that.
+ */
+function discoverLinkedAssets() {
+  const mdFiles = globSync("**/*.md", { ignore: NON_DOC_GLOBS });
+  const code = new Set();
+  const page = new Set();
+  const inlineRe = /\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  const refDefRe = /^[ \t]*\[([^\]]+)\]:[ \t]+(\S+)/gm;
+  const refUseRe = /\[(?:[^\]\n]|\\\])*\]\[([^\]\n]+)\]/g;
+
+  function classify(url, mdDir) {
+    const clean = url.split("#")[0].split("?")[0];
+    if (!clean || /^[a-z]+:\/\//i.test(clean) || clean.startsWith("/")) return;
+    if (clean.endsWith(".md") || clean.endsWith("/")) return;
+    const target = posix.normalize(posix.join(mdDir, clean));
+    if (target.startsWith("..") || !existsSync(target)) return;
+    const base = basename(target);
+    const dot = base.lastIndexOf(".");
+    const ext = dot > 0 ? base.slice(dot + 1).toLowerCase() : "";
+    // VitePress ignores dotfile-prefixed paths when scanning sources, so a
+    // `.X.md` wrapper there won't be built — treat those as raw assets.
+    const inHiddenDir = target.split("/").some((seg) => seg.startsWith("."));
+    // Extensionless files (LICENSE, etc.) get raw at native URL — no language
+    // to highlight, and a wrapper would collide with the page build.
+    if (BROWSER_HANDLES.has(ext) || inHiddenDir || !ext) {
+      page.add(target);
+    } else {
+      code.add(target);
+    }
+  }
+
+  for (const mdFile of mdFiles) {
+    const stripped = readFileSync(mdFile, "utf-8")
+      .replace(/```[\s\S]*?```/g, "") // skip fenced code blocks
+      .replace(/`[^`]*`/g, "");       // skip inline code
+    const mdDir = dirname(mdFile);
+    for (const match of stripped.matchAll(inlineRe)) {
+      classify(match[1], mdDir);
+    }
+    const refDefs = new Map();
+    for (const match of stripped.matchAll(refDefRe)) {
+      refDefs.set(match[1].toLowerCase(), match[2]);
+    }
+    for (const match of stripped.matchAll(refUseRe)) {
+      const url = refDefs.get(match[1].toLowerCase());
+      if (url) classify(url, mdDir);
+    }
+  }
+  return { code: [...code], page: [...page] };
+}
+
+/**
+ * Auto-generate a `.X.md` wrapper for each linked code file that lacks one.
+ * Wrappers hold just a frontmatter stanza and a `<<<` snippet import; vitepress
+ * builds the rendered viewer page from them.
+ */
+function ensureCodeWrappers(codeAssets) {
+  for (const target of codeAssets) {
+    const wrapperPath = target + ".md";
+    if (existsSync(wrapperPath)) continue;
+    const title = basename(target);
+    writeFileSync(
+      wrapperPath,
+      `---\ntitle: "${title}"\nlayout: code-only\n---\n\n<<< @/${target}\n`,
+    );
+  }
+}
+
+/**
+ * Vite plugin that publishes non-markdown linked assets to the docs site so
+ * relative links from markdown resolve to a real URL. Build mode emits files
+ * into `dist/`; dev mode serves the same URLs via middleware.
+ */
+function linkedAssetsPlugin({ code, page }) {
+  let base = "/";
+  const codeSet = new Set(code);
+  const pageSet = new Set(page);
+  return {
+    name: "linked-assets",
+    configResolved(config) {
+      base = config.base;
+    },
+    generateBundle() {
+      for (const target of codeSet) {
+        this.emitFile({
+          type: "asset",
+          fileName: target + ".raw",
+          source: readFileSync(target),
+        });
+      }
+      for (const target of pageSet) {
+        this.emitFile({
+          type: "asset",
+          fileName: target,
+          source: readFileSync(target),
+        });
+      }
+    },
+    configureServer(server) {
+      const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      function stripBase(url) {
+        const match = url.match(
+          new RegExp(`^${escapedBase}(.+?)(?:\\?.*)?$`),
+        );
+        return match ? match[1] : null;
+      }
+      server.middlewares.use((req, res, next) => {
+        const path = stripBase(req.url ?? "");
+        if (!path) return next();
+        if (path.endsWith(".raw")) {
+          const target = path.slice(0, -".raw".length);
+          if (codeSet.has(target)) {
+            try {
+              res.setHeader("content-type", "text/plain; charset=utf-8");
+              res.end(readFileSync(target));
+            } catch {
+              next();
+            }
+            return;
+          }
+        }
+        const pageTarget = pageSet.has(path) ? path :
+          pageSet.has(path + ".html") ? path + ".html" :
+          null;
+        if (pageTarget) {
+          try {
+            const ext = pageTarget
+              .slice(pageTarget.lastIndexOf(".") + 1)
+              .toLowerCase();
+            res.setHeader(
+              "content-type",
+              MIME_TYPES[ext] || "text/plain; charset=utf-8",
+            );
+            res.end(readFileSync(pageTarget));
+          } catch {
+            next();
+          }
+          return;
+        }
+        // Code native URL: rewrite to SPA shell so the rendered viewer page
+        // wins over vite's static-file serving of the raw source.
+        if (codeSet.has(path)) {
+          req.url = base;
+        }
+        next();
+      });
+    },
+  };
+}
+
+// Discover linked assets and ensure code wrappers exist *before* vitepress
+// scans for source `.md` files — otherwise the auto-generated wrappers won't
+// show up in the page map for the first build.
+const linkedAssets = discoverLinkedAssets();
+ensureCodeWrappers(linkedAssets.code);
+
+const { nav, sidebar } = generateNav();
+
+export default defineConfig({
+  title: "sh-cmd-tag",
+  description:
+    "Template tag functions for shell command execution with streaming " +
+    "output, safe interpolation, and flexible I/O control",
+  base: new URL(DOCS_BASE).pathname,
+  cleanUrls: true,
+  srcDir: ".",
+  srcExclude: [
+    "**/node_modules/**",
+    ".vitepress/**",
+    ".worktrees/**",
+    ".github/**",
+    "docs/**",
+    "specs/**",
+    "prompts/**",
+    "scripts/**",
+    "dist/**",
+    "README.md",
+    "STYLE.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "**/*.test.*.md",
+  ],
+
+  vite: {
+    resolve: {
+      alias: [
+        {
+          // Swap the built-in local-search box for our fork, which builds a
+          // best-match excerpt from the indexed page text.
+          find: /^.*[\\/]VPLocalSearchBox\.vue$/,
+          replacement: fileURLToPath(
+            new URL("./theme/components/CustomSearchBox.vue", import.meta.url),
+          ),
+        },
+      ],
+    },
+    define: {
+      "import.meta.env.VITE_EXTRA_EXTENSIONS":
+        JSON.stringify(process.env.VITE_EXTRA_EXTENSIONS),
+    },
+    plugins: [linkedAssetsPlugin(linkedAssets)],
+  },
+
+  themeConfig: {
+    nav: [
+      { text: "Home", link: "/" },
+      ...nav,
+    ],
+    sidebar,
+    socialLinks: [
+      { icon: "github", link: "https://github.com/chriscalo/sh-cmd-tag" },
+    ],
+    search: {
+      provider: "local",
+      options: {
+        // Show a content excerpt with highlighted matches under each result's
+        // title, so you can see *what* matched, not just which page.
+        detailedView: true,
+        _render: renderForIndex,
+        miniSearch: {
+          options: {
+            tokenize,
+            processTerm,
+            // Keep the rendered page text in the index so the search component
+            // can build a best-match excerpt on the client.
+            storeFields: ["title", "titles", "text"],
+          },
+          searchOptions: {
+            combineWith: "AND",
+            fuzzy: false,
+            prefix: true,
+            boost: { title: 4, titles: 2, text: 1 },
+          },
+        },
+      },
+    },
+  },
+
+  transformPageData(pageData) {
+    // Derive the copy-link URL from the same helper the site's own links use.
+    pageData.fullUrl = repoPathToUrl(pageData.relativePath);
+
+    // Breadcrumb trail rendered above the page title.
+    pageData.breadcrumbs = buildBreadcrumbs(pageData.relativePath);
+
+    // Raw markdown for the copy-markdown button.
+    try {
+      const content = readFileSync(pageData.filePath, "utf-8");
+      pageData.markdownSourceBase64 = Buffer.from(content).toString("base64");
+    } catch {
+      pageData.markdownSourceBase64 = null;
+    }
+  },
+});

--- a/.vitepress/nav.js
+++ b/.vitepress/nav.js
@@ -1,0 +1,155 @@
+import { globSync } from "glob";
+import matter from "gray-matter";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+
+// Files that never belong in the generated navigation. The root `index.md` is
+// the homepage (its own nav entry), and anything under these directories is
+// either build machinery or non-topic content.
+const EXCLUDE = [
+  "node_modules/**",
+  ".vitepress/**",
+  ".worktrees/**",
+  ".github/**",
+  "docs/**",
+  "specs/**",
+  "prompts/**",
+  "scripts/**",
+  "index.md",
+];
+
+// Co-located artifact files keyed off the established extension conventions:
+// tests, specs, worked examples, prompt templates, and fill-in templates. They
+// are linked from the topic page that documents them, not standalone topics.
+// Keying off the extension (rather than a single marker) keeps a `.spec.md`
+// discoverable by a spec runner while staying out of the nav.
+const ARTIFACT = /\.(test|spec|example|prompt|template)\./;
+
+/**
+ * Title-case a hyphen/dot-separated segment. `getting-started` → `Getting
+ * Started`. Abbreviations and proper nouns should be fixed with an explicit
+ * frontmatter `title` rather than relying on this fallback.
+ */
+export function formatSegment(segment) {
+  return segment
+    .split(/[-.]/)
+    .map(word => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(" ");
+}
+
+function extractFrontmatter(filePath) {
+  try {
+    return matter(readFileSync(filePath, "utf-8")).data;
+  } catch {
+    return {};
+  }
+}
+
+function extractTitle(filePath) {
+  return (
+    extractFrontmatter(filePath).title || formatSegment(basename(filePath, ".md"))
+  );
+}
+
+/**
+ * The canonical set of repo-relative `.md` paths the site deliberately indexes:
+ * every markdown topic page minus the carve-outs (the excluded directories, the
+ * homepage, co-located artifact files, and auto-generated `layout: code-only`
+ * source-viewer wrappers). Both the nav (`generateNav`) and the coverage test
+ * derive from this single list so the surfaces can't silently drift.
+ */
+export function indexedPages({ exclude = [] } = {}) {
+  const ignore = [...EXCLUDE, ...exclude];
+  return globSync("**/*.md", { ignore })
+    .filter(f => !ARTIFACT.test(basename(f)))
+    .filter(f => extractFrontmatter(f).layout !== "code-only")
+    .sort();
+}
+
+function pageFor(file) {
+  return {
+    file,
+    segments: file.replace(/\.md$/, "").split("/"),
+    title: extractTitle(file),
+    link: "/" + file.replace(/\.md$/, "").replace(/\/index$/, "/"),
+  };
+}
+
+function groupByTopLevel(pages) {
+  const groups = new Map();
+  for (const page of pages) {
+    const key = page.segments[0];
+    if (!groups.has(key)) {
+      groups.set(key, { key, name: formatSegment(key), pages: [] });
+    }
+    groups.get(key).pages.push(page);
+  }
+  return [...groups.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function isSingleTopLevelFile(section) {
+  return section.pages.length === 1 && section.pages[0].segments.length === 1;
+}
+
+/**
+ * The display title for a section, preferring the section's own index page
+ * frontmatter title (`guide/index.md`) over the formatted directory name.
+ */
+function sectionTitle(section) {
+  const indexPage = section.pages.find(p => p.link === `/${section.key}/`);
+  return indexPage ? indexPage.title : section.name;
+}
+
+function buildNav(sections) {
+  return sections.map(section => {
+    if (isSingleTopLevelFile(section)) {
+      const page = section.pages[0];
+      return { text: page.title, link: page.link };
+    }
+    // Prefer the section index page; otherwise link to the first page.
+    const indexPage = section.pages.find(p => p.link === `/${section.key}/`);
+    const sorted = [...section.pages].sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
+    return {
+      text: sectionTitle(section),
+      link: (indexPage || sorted[0]).link,
+    };
+  });
+}
+
+function buildSidebarGroup(section) {
+  const items = [...section.pages]
+    // The section index page heads the group as its top link, not a child item.
+    .filter(p => p.link !== `/${section.key}/`)
+    .map(p => ({ text: p.title, link: p.link }))
+    .sort((a, b) => a.text.localeCompare(b.text));
+  const group = { text: sectionTitle(section), items };
+  if (section.pages.some(p => p.link === `/${section.key}/`)) {
+    group.link = `/${section.key}/`;
+  }
+  return group;
+}
+
+function buildSidebar(sections) {
+  const sidebar = {};
+  for (const section of sections) {
+    if (isSingleTopLevelFile(section)) continue;
+    sidebar[`/${section.key}/`] = [buildSidebarGroup(section)];
+  }
+  return sidebar;
+}
+
+/**
+ * Generate VitePress `nav` and `sidebar` config from the file system. The
+ * folder structure is the single source of truth: add or move a markdown file
+ * and the navigation updates at build time.
+ */
+export function generateNav({ exclude = [] } = {}) {
+  const pages = indexedPages({ exclude }).map(pageFor);
+  const sections = groupByTopLevel(pages);
+  return {
+    nav: buildNav(sections),
+    sidebar: buildSidebar(sections),
+  };
+}

--- a/.vitepress/nav.test.js
+++ b/.vitepress/nav.test.js
@@ -1,0 +1,57 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { repoPathToUrl, DOCS_BASE } from "./url.js";
+import { generateNav, indexedPages } from "./nav.js";
+
+// Strip the docs-site origin + base path so a repo path maps to the same
+// site-root-relative link the nav emits (`/guide/getting-started`). Using
+// `repoPathToUrl` (covered by url.test.js) as an independent oracle means this
+// test cross-checks the nav's link format rather than trusting it.
+const BASE_PATH = new URL(DOCS_BASE).pathname.replace(/\/$/, "");
+
+function navLink(repoPath) {
+  return new URL(repoPathToUrl(repoPath)).pathname.slice(BASE_PATH.length);
+}
+
+function allNavLinks() {
+  const { nav, sidebar } = generateNav();
+  const links = new Set();
+  for (const entry of nav) {
+    if (entry.link) links.add(entry.link);
+  }
+  for (const groups of Object.values(sidebar)) {
+    for (const group of groups) {
+      if (group.link) links.add(group.link);
+      for (const item of group.items ?? []) {
+        if (item.link) links.add(item.link);
+      }
+    }
+  }
+  return links;
+}
+
+// The nav must cover the indexed-page set: every indexed page is reachable from
+// the generated nav or sidebar, and the nav surfaces nothing outside that set
+// (so an artifact file or a `code-only` wrapper can never leak into the nav).
+describe("generateNav matches the indexed-page set", () => {
+  const expected = new Set(indexedPages().map(navLink));
+  const actual = allNavLinks();
+
+  test("the nav links every indexed page (coverage)", () => {
+    const missing = [...expected].filter(link => !actual.has(link)).sort();
+    assert.deepEqual(
+      missing,
+      [],
+      `the nav is missing links for indexed pages:\n${missing.join("\n")}`,
+    );
+  });
+
+  test("the nav links nothing outside the indexed set (no artifacts)", () => {
+    const strays = [...actual].filter(link => !expected.has(link)).sort();
+    assert.deepEqual(
+      strays,
+      [],
+      `the nav links pages that are not indexed:\n${strays.join("\n")}`,
+    );
+  });
+});

--- a/.vitepress/search-helpers.js
+++ b/.vitepress/search-helpers.js
@@ -1,0 +1,65 @@
+// Headings we flatten into paragraphs at index time (see renderForIndex).
+const COLLAPSED_HEADINGS = new Set(["h2", "h3", "h4"]);
+
+// VitePress's local-search indexer starts a brand-new search entry at every
+// H2–H4 heading, so a single page can show up as a handful of near-duplicate
+// hits. We stop that by flattening those headings into ordinary paragraphs
+// before the page is indexed — then the whole page indexes as one entry.
+//
+// We do the flattening on markdown-it's *token stream* rather than by
+// find-and-replacing tags in the rendered HTML string. markdown-it first
+// turns the markdown into a list of tokens (one per element — heading, list,
+// paragraph, …) and then walks that list to produce HTML. `md.parse` hands
+// us that list; we relabel each heading token's tag as "p"; `md.renderer`
+// turns the adjusted list back into HTML. No HTML is ever parsed with a
+// regex, and any attributes on a heading (like an anchor `id`) ride along
+// untouched because we only change the tag name. This is the same
+// token-level technique `skillLinkPlugin` uses in config.js.
+export function renderForIndex(src, env, md) {
+  const tokens = md.parse(src, env);
+  for (const token of tokens) {
+    const isHeading =
+      token.type === "heading_open" || token.type === "heading_close";
+    if (isHeading && COLLAPSED_HEADINGS.has(token.tag)) {
+      token.tag = "p";
+    }
+  }
+  return md.renderer.render(tokens, md.options, env);
+}
+
+// CRITICAL: `tokenize` and `processTerm` are handed to MiniSearch through
+// `search.options.miniSearch.options`, and VitePress ships those to the browser
+// by serializing each one with `Function.prototype.toString()` and rebuilding
+// it on the client. Only the function's *own source* survives that round-trip —
+// any reference to a module-scope helper, constant, or import becomes a
+// ReferenceError the moment the rebuilt function runs in the browser. MiniSearch
+// swallows that error and every query silently returns zero results (the bug
+// fixed in #569). So both functions MUST be fully self-contained: inline every
+// regex and every helper inside the function body, no outside references.
+export function tokenize(text) {
+  // Split at whitespace and the punctuation that separates words inside
+  // identifiers, paths, and filenames: hyphens, underscores, dots, and
+  // slashes. So `my-func` → ["my", "func"] and `scripts/skills.sh` →
+  // ["scripts", "skills", "sh"]. Splitting on `.` and `/` is what lets a
+  // query like `skills.sh` find a page that only mentions
+  // `./scripts/skills.sh` — without it, the whole path indexes as one token
+  // that a sub-path query can't prefix-match (the bug fixed in #581).
+  const WORD_SEPARATORS = /[\s\-_./]+/;
+  // camelCase boundaries: a lowercase letter or digit before an uppercase one
+  // (`getHTTP` → ["get", "HTTP"]), and an uppercase letter before an
+  // uppercase+lowercase pair (`HTTPResponse` → ["HTTP", "Response"]).
+  const CAMELCASE_BOUNDARY = /(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/;
+  return text
+    .split(WORD_SEPARATORS)
+    .filter(Boolean)
+    .flatMap((word) => {
+      const parts = word.split(CAMELCASE_BOUNDARY).filter(Boolean);
+      // Keep the original token alongside its parts so a whole-identifier query
+      // like "httpresponse" still prefix-matches `HTTPResponse` in the index.
+      return parts.length > 1 ? [...parts, word] : parts;
+    });
+}
+
+export function processTerm(term) {
+  return term.toLowerCase();
+}

--- a/.vitepress/theme/CodeOnlyLayout.vue
+++ b/.vitepress/theme/CodeOnlyLayout.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="code-only-layout">
+    <a class="raw-link" :href="rawUrl" target="_blank" rel="noopener">raw</a>
+    <Content />
+  </div>
+</template>
+
+<script setup>
+  import { Content, useData } from "vitepress";
+  import { computed } from "vue";
+  
+  const { page, site } = useData();
+  const rawUrl = computed(() => {
+    const sourcePath = page.value.relativePath.replace(/\.md$/, "");
+    return site.value.base + sourcePath + ".raw";
+  });
+</script>
+
+<style>
+  html:has(.code-only-layout),
+  body:has(.code-only-layout) {
+    margin: 0;
+    padding: 0;
+  }
+  
+  .code-only-layout {
+    background: var(--vp-c-bg);
+    min-height: 100vh;
+    position: relative;
+  }
+  
+  .code-only-layout .raw-link {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 10;
+    color: var(--vp-c-text-2);
+    font-family: var(--vp-font-family-mono);
+    font-size: 0.85rem;
+    text-decoration: none;
+  }
+  
+  .code-only-layout .raw-link:hover {
+    color: var(--vp-c-brand-1);
+    text-decoration: underline;
+  }
+  
+  .code-only-layout > div {
+    padding: 0;
+    margin: 0;
+  }
+  
+  .code-only-layout div[class*="language-"] {
+    margin: 0;
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
+  }
+  
+  .code-only-layout div[class*="language-"] pre {
+    padding: 1.5rem;
+    line-height: 1.5;
+  }
+  
+  .code-only-layout div[class*="language-"] .copy {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+  
+  /* Hide vitepress's language label (e.g. "sh") that floats over the
+     top-right of every code block. */
+  .code-only-layout div[class*="language-"] .lang {
+    display: none;
+  }
+  
+  /* The wrapper .md file has just a code-import directive — hide any stray
+     heading/empty paragraph vitepress adds around it. */
+  .code-only-layout h1,
+  .code-only-layout p:empty {
+    display: none;
+  }
+</style>

--- a/.vitepress/theme/CopyButtons.vue
+++ b/.vitepress/theme/CopyButtons.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="copy-buttons">
+    <button
+      class="inline-copy-btn"
+      :class="{ copied: linkCopied }"
+      aria-live="polite"
+      @mousedown.prevent
+      @click="copyLink"
+    >
+      <span data-state="idle" :aria-hidden="String(linkCopied)">
+        <LinkIcon />
+        Copy Link
+      </span>
+      <span
+        data-state="success"
+        :aria-hidden="String(!linkCopied)"
+        role="status"
+      >
+        <CheckIcon />
+        Copied!
+      </span>
+    </button>
+    <button
+      class="inline-copy-btn"
+      :class="{ copied: markdownCopied }"
+      aria-live="polite"
+      @mousedown.prevent
+      @click="copyMarkdown"
+      :disabled="!hasMarkdownSource"
+    >
+      <span
+        data-state="idle"
+        :aria-hidden="String(markdownCopied)"
+      >
+        <DocIcon />
+        Copy Markdown
+      </span>
+      <span
+        data-state="success"
+        :aria-hidden="String(!markdownCopied)"
+        role="status"
+      >
+        <CheckIcon />
+        Copied!
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup>
+  import { ref, computed, h } from "vue";
+  import { useData } from "vitepress";
+  
+  const { page } = useData();
+  
+  const ICON_ATTRS = {
+    xmlns: "http://www.w3.org/2000/svg",
+    width: "14",
+    height: "14",
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "2",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  };
+  
+  const LinkIcon = () => h("svg", ICON_ATTRS, [
+    h("path", {
+      d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71",
+    }),
+    h("path", {
+      d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71",
+    }),
+  ]);
+  
+  const CheckIcon = () => h("svg", ICON_ATTRS, [
+    h("polyline", { points: "20 6 9 17 4 12" }),
+  ]);
+  
+  const DocIcon = () => h("svg", ICON_ATTRS, [
+    h("path", {
+      d: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z",
+    }),
+    h("polyline", { points: "14 2 14 8 20 8" }),
+    h("line", { x1: "16", y1: "13", x2: "8", y2: "13" }),
+    h("line", { x1: "16", y1: "17", x2: "8", y2: "17" }),
+    h("polyline", { points: "10 9 9 9 8 9" }),
+  ]);
+  
+  const linkCopied = ref(false);
+  const markdownCopied = ref(false);
+  
+  const hasMarkdownSource = computed(
+    () => Boolean(page.value.markdownSourceBase64),
+  );
+  
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(page.value.fullUrl);
+      linkCopied.value = true;
+      setTimeout(() => linkCopied.value = false, 2000);
+    } catch (err) {
+      console.error("Failed to copy link:", err);
+    }
+  }
+  
+  async function copyMarkdown() {
+    try {
+      const markdown = atob(page.value.markdownSourceBase64);
+      await navigator.clipboard.writeText(markdown);
+      markdownCopied.value = true;
+      setTimeout(() => markdownCopied.value = false, 2000);
+    } catch (err) {
+      console.error("Failed to copy markdown:", err);
+    }
+  }
+</script>

--- a/.vitepress/theme/CustomLayout.vue
+++ b/.vitepress/theme/CustomLayout.vue
@@ -1,0 +1,33 @@
+<template>
+  <CodeOnlyLayout v-if="frontmatter.layout === 'code-only'" />
+  <Layout v-else>
+    <template #doc-before>
+      <div class="doc-action-buttons">
+        <CopyButtons />
+        <FileABug />
+      </div>
+      <nav
+        v-if="page.breadcrumbs && page.breadcrumbs.length"
+        class="breadcrumbs"
+        aria-label="Breadcrumb"
+      >
+        <template v-for="(crumb, index) in page.breadcrumbs" :key="index">
+          <span v-if="index > 0" class="breadcrumbs-separator">/</span>
+          <a v-if="crumb.link" :href="withBase(crumb.link)">{{ crumb.text }}</a>
+          <span v-else>{{ crumb.text }}</span>
+        </template>
+      </nav>
+    </template>
+  </Layout>
+</template>
+
+<script setup>
+  import DefaultTheme from "vitepress/theme";
+  import { useData, withBase } from "vitepress";
+  import CopyButtons from "./CopyButtons.vue";
+  import FileABug from "./FileABug.vue";
+  import CodeOnlyLayout from "./CodeOnlyLayout.vue";
+  
+  const { Layout } = DefaultTheme;
+  const { frontmatter, page } = useData();
+</script>

--- a/.vitepress/theme/FileABug.vue
+++ b/.vitepress/theme/FileABug.vue
@@ -1,0 +1,100 @@
+<template>
+  <button
+    class="inline-copy-btn file-a-bug-btn"
+    @mousedown.prevent
+    @click="fileABug"
+  >
+    <BugIcon />
+    File a Bug
+  </button>
+</template>
+
+<script setup>
+  import { h } from "vue";
+  import { useData } from "vitepress";
+
+  const { page } = useData();
+
+  const ICON_ATTRS = {
+    xmlns: "http://www.w3.org/2000/svg",
+    width: "14",
+    height: "14",
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "2",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  };
+
+  const BugIcon = () => h("svg", ICON_ATTRS, [
+    h("path", { d: "m8 2 1.88 1.88" }),
+    h("path", { d: "M14.12 3.88 16 2" }),
+    h("path", {
+      d: "M9 7.13v-1a3.003 3.003 0 1 1 6 0v1",
+    }),
+    h("path", {
+      d: "M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1"
+        + " 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6",
+    }),
+    h("path", { d: "M12 20v-9" }),
+    h("path", { d: "M6.53 9C4.6 8.8 3 7.1 3 5" }),
+    h("path", { d: "M6 13H2" }),
+    h("path", {
+      d: "M3 21c0-2.1 1.7-3.9 3.8-4",
+    }),
+    h("path", {
+      d: "M20.97 5c0 2.1-1.6 3.8-3.5 4",
+    }),
+    h("path", { d: "M22 13h-4" }),
+    h("path", {
+      d: "M17.2 17c2.1.1 3.8 1.9 3.8 4",
+    }),
+  ]);
+
+  const MAX_SELECTION = 2000;
+  const MAX_URL_LENGTH = 8000;
+  const ELLIPSIS = "…";
+
+  function buildIssueUrl(selectedText) {
+    const url = new URL(
+      "https://github.com/chriscalo/sh-cmd-tag/issues/new",
+    );
+    const pageUrl = page.value.fullUrl || location.href;
+    const parts = [`**Page:** ${pageUrl}`];
+    if (selectedText) {
+      const quoted = selectedText
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      parts.push(`**Selected text:**\n${quoted}`);
+    }
+    url.searchParams.set("body", parts.join("\n\n"));
+    return url;
+  }
+
+  function fileABug() {
+    let selectedText =
+      window.getSelection()?.toString().trim() || "";
+    if (selectedText.length > MAX_SELECTION) {
+      selectedText =
+        selectedText.slice(0, MAX_SELECTION - ELLIPSIS.length) + ELLIPSIS;
+    }
+    let url = buildIssueUrl(selectedText);
+    while (
+      url.toString().length > MAX_URL_LENGTH
+      && selectedText.length > ELLIPSIS.length
+    ) {
+      const target = Math.max(
+        ELLIPSIS.length,
+        Math.floor(selectedText.length * 0.8),
+      );
+      selectedText =
+        selectedText.slice(0, target - ELLIPSIS.length) + ELLIPSIS;
+      url = buildIssueUrl(selectedText);
+    }
+    window.open(
+      url.toString(), "_blank", "noopener,noreferrer",
+    );
+  }
+</script>

--- a/.vitepress/theme/components/CustomSearchBox.vue
+++ b/.vitepress/theme/components/CustomSearchBox.vue
@@ -1,0 +1,724 @@
+<script setup>
+  import localSearchIndex from "@localSearchIndex";
+  import {
+    computedAsync,
+    watchDebounced,
+    onKeyStroke,
+    useEventListener,
+    useScrollLock,
+    useSessionStorage
+  } from "@vueuse/core";
+  import { useFocusTrap } from "@vueuse/integrations/useFocusTrap";
+  import Mark from "mark.js/src/vanilla.js";
+  import MiniSearch from "minisearch";
+  import { inBrowser, useData, useRouter } from "vitepress";
+  import {
+    computed,
+    markRaw,
+    nextTick,
+    onBeforeUnmount,
+    onMounted,
+    ref,
+    shallowRef,
+    watch,
+  } from "vue";
+  import { escapeRegExp } from "vitepress/dist/client/shared.js";
+  import {
+    createSearchTranslate
+  } from "vitepress/dist/client/theme-default/support/translation.js";
+  
+  const emit = defineEmits(["close"]);
+  
+  const rootEl = shallowRef();
+  const resultsEl = shallowRef();
+  
+  /* Search */
+  
+  const searchIndexData = shallowRef(localSearchIndex);
+  
+  // hmr
+  if (import.meta.hot) {
+    import.meta.hot.accept("@localSearchIndex", (mod) => {
+      if (mod) {
+        searchIndexData.value = mod.default;
+      }
+    });
+  }
+  
+  const vitePressData = useData();
+  const { activate } = useFocusTrap(rootEl, {
+    immediate: true,
+    allowOutsideClick: true,
+    clickOutsideDeactivates: true,
+    escapeDeactivates: true,
+  });
+  const { localeIndex, theme } = vitePressData;
+  const searchIndex = computedAsync(async () =>
+    markRaw(
+      MiniSearch.loadJSON(
+        (await searchIndexData.value[localeIndex.value]?.())?.default,
+        {
+          fields: ["title", "titles", "text"],
+          storeFields: ["title", "titles", "text"],
+          searchOptions: {
+            fuzzy: 0.2,
+            prefix: true,
+            boost: { title: 4, text: 2, titles: 1 },
+            ...(theme.value.search?.provider === "local" &&
+              theme.value.search.options?.miniSearch?.searchOptions),
+          },
+          ...(theme.value.search?.provider === "local" &&
+            theme.value.search.options?.miniSearch?.options),
+        },
+      ),
+    ),
+  );
+  
+  const disableQueryPersistence = computed(() => {
+    return (
+      theme.value.search?.provider === "local" &&
+      theme.value.search.options?.disableQueryPersistence === true
+    );
+  });
+  
+  const filterText = disableQueryPersistence.value ?
+    ref("") :
+    useSessionStorage("vitepress:local-search-filter", "");
+  
+  const results = shallowRef([]);
+  
+  const enableNoResults = ref(false);
+  
+  watch(filterText, () => {
+    enableNoResults.value = false;
+  });
+  
+  const mark = computedAsync(async () => {
+    if (!resultsEl.value) return;
+    return markRaw(new Mark(resultsEl.value));
+  }, null);
+  
+  // Build a result's excerpt from the page text stored in the search index:
+  // find the earliest place any matched term occurs, slice a window around
+  // it, and trim to word boundaries. Returns escaped HTML; mark.js
+  // highlights the terms afterward, the same as for the title.
+  function buildExcerpt(text, match) {
+    if (!text) return "";
+    // The indexed text strips tags but keeps HTML entities (`&amp;`, `&#8203;`,
+    // …). Decode them to real characters first, so windowing can't slice an
+    // entity in half and escaping below can't double-encode it.
+    const decoder = document.createElement("textarea");
+    decoder.innerHTML = text;
+    text = decoder.value;
+    function escapeHtml(str) {
+      return str.replace(
+        /[&<>"]/g,
+        (char) =>
+          ({
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            [`"`]: "&quot;",
+          })[char],
+      );
+    }
+    const lower = text.toLowerCase();
+    let pos = -1;
+    for (const term in match) {
+      const termIndex = lower.indexOf(term.toLowerCase());
+      if (termIndex !== -1 && (pos === -1 || termIndex < pos)) pos = termIndex;
+    }
+    const WINDOW = 200;
+    const start = pos === -1 ? 0 : Math.max(0, pos - 50);
+    let slice = text.slice(start, start + WINDOW);
+    if (start > 0) slice = "…" + slice.replace(/^\S+\s/, "");
+    if (start + WINDOW < text.length) slice = slice.replace(/\s\S+$/, "") + "…";
+    return `<p>${escapeHtml(slice)}</p>`;
+  }
+  
+  watchDebounced(
+    () => [searchIndex.value, filterText.value],
+    async ([index, filterTextValue], old, onCleanup) => {
+      let canceled = false;
+      onCleanup(() => {
+        canceled = true;
+      });
+      if (!index) return;
+      // Search
+      results.value = index
+        .search(filterTextValue)
+        .slice(0, 16);
+      enableNoResults.value = true;
+      // Build each result's excerpt by windowing the page text (stored in the
+      // index via `storeFields`) around the best query match. There's no
+      // per-result page fetch, so the result list never re-renders mid-search.
+      const terms = new Set();
+      results.value = results.value.map((entry) => {
+        for (const term in entry.match) {
+          terms.add(term);
+        }
+        return { ...entry, text: buildExcerpt(entry.text, entry.match) };
+      });
+      await nextTick();
+      if (canceled) return;
+      await new Promise((resolve) => {
+        mark.value?.unmark({
+          done: () => {
+            mark.value?.markRegExp(formMarkRegex(terms), { done: resolve });
+          }
+        });
+      });
+      const excerpts = rootEl.value?.querySelectorAll(".result .excerpt") ?? [];
+      for (const excerpt of excerpts) {
+        excerpt
+          .querySelector(`mark[data-markjs="true"]`)
+          ?.scrollIntoView({ block: "center" });
+      }
+      // FIXME: without this whole page scrolls to the bottom
+      resultsEl.value?.firstElementChild?.scrollIntoView({ block: "start" });
+    },
+    { debounce: 200, immediate: true },
+  );
+  
+  /* Search input focus */
+  
+  const searchInput = ref();
+  const disableReset = computed(() => {
+    return filterText.value?.length <= 0;
+  });
+  function focusSearchInput(select = true) {
+    searchInput.value?.focus();
+    select && searchInput.value?.select();
+  }
+  
+  onMounted(() => {
+    focusSearchInput();
+  });
+  
+  function onSearchBarClick(event) {
+    if (event.pointerType === "mouse") {
+      focusSearchInput();
+    }
+  }
+  
+  /* Search keyboard selection */
+  
+  const selectedIndex = ref(-1);
+  const disableMouseOver = ref(true);
+  
+  watch(results, (list) => {
+    selectedIndex.value = list.length ? 0 : -1;
+    scrollToSelectedResult();
+  });
+  
+  function scrollToSelectedResult() {
+    nextTick(() => {
+      const selectedEl = document.querySelector(".result.selected");
+      selectedEl?.scrollIntoView({ block: "nearest" });
+    });
+  }
+  
+  onKeyStroke("ArrowUp", (event) => {
+    event.preventDefault();
+    selectedIndex.value--;
+    if (selectedIndex.value < 0) {
+      selectedIndex.value = results.value.length - 1;
+    }
+    disableMouseOver.value = true;
+    scrollToSelectedResult();
+  });
+  
+  onKeyStroke("ArrowDown", (event) => {
+    event.preventDefault();
+    selectedIndex.value++;
+    if (selectedIndex.value >= results.value.length) {
+      selectedIndex.value = 0;
+    }
+    disableMouseOver.value = true;
+    scrollToSelectedResult();
+  });
+  
+  const router = useRouter();
+  
+  onKeyStroke("Enter", (event) => {
+    if (event.isComposing) return;
+    if (
+      event.target instanceof HTMLButtonElement &&
+      event.target.type !== "submit"
+    ) {
+      return;
+    }
+    const selectedPackage = results.value[selectedIndex.value];
+    if (event.target instanceof HTMLInputElement && !selectedPackage) {
+      event.preventDefault();
+      return;
+    }
+    if (selectedPackage) {
+      router.go(selectedPackage.id);
+      emit("close");
+    }
+  });
+  
+  onKeyStroke("Escape", () => {
+    emit("close");
+  });
+  
+  /* Translations */
+  
+  const defaultTranslations = {
+    button: {
+      buttonText: "Search"
+    },
+    modal: {
+      displayDetails: "Display detailed list",
+      resetButtonTitle: "Reset search",
+      backButtonTitle: "Close search",
+      noResultsText: "No results for",
+      footer: {
+        selectText: "to select",
+        selectKeyAriaLabel: "enter",
+        navigateText: "to navigate",
+        navigateUpKeyAriaLabel: "up arrow",
+        navigateDownKeyAriaLabel: "down arrow",
+        closeText: "to close",
+        closeKeyAriaLabel: "escape",
+      },
+    },
+  };
+  
+  const translate = createSearchTranslate(defaultTranslations);
+  
+  /* Back */
+  
+  onMounted(() => {
+    // Prevents going to previous site
+    window.history.pushState(null, "", null);
+  });
+  
+  useEventListener("popstate", (event) => {
+    event.preventDefault();
+    emit("close");
+  });
+  
+  /** Lock body */
+  
+  const isLocked = useScrollLock(inBrowser ? document.body : null);
+  
+  onMounted(() => {
+    nextTick(() => {
+      isLocked.value = true;
+      nextTick().then(() => activate());
+    });
+  });
+  
+  onBeforeUnmount(() => {
+    isLocked.value = false;
+  });
+  
+  function resetSearch() {
+    filterText.value = "";
+    nextTick().then(() => focusSearchInput(false));
+  }
+  
+  function formMarkRegex(terms) {
+    return new RegExp(
+      [...terms]
+        .sort((left, right) => right.length - left.length)
+        .map((term) => `(${escapeRegExp(term)})`)
+        .join("|"),
+      "gi",
+    );
+  }
+  
+  function onMouseMove(event) {
+    if (!disableMouseOver.value) return;
+    const resultEl = event.target
+      ?.closest(".result");
+    const index = Number.parseInt(resultEl?.dataset.index);
+    if (index >= 0 && index !== selectedIndex.value) {
+      selectedIndex.value = index;
+    }
+    disableMouseOver.value = false;
+  }
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="rootEl"
+      role="button"
+      :aria-owns="results?.length ? 'localsearch-list' : undefined"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-labelledby="localsearch-label"
+      class="VPLocalSearchBox"
+    >
+      <div class="backdrop" @click="$emit('close')" />
+
+      <div class="shell">
+        <form
+          class="search-bar"
+          @pointerup="onSearchBarClick($event)"
+          @submit.prevent=""
+        >
+          <label
+            :title="translate('button.buttonText')"
+            id="localsearch-label"
+            for="localsearch-input"
+          >
+            <span
+              aria-hidden="true"
+              class="vpi-search search-icon local-search-icon"
+            />
+          </label>
+          <div class="search-actions before">
+            <button
+              class="back-button"
+              :title="translate('modal.backButtonTitle')"
+              @click="$emit('close')"
+            >
+              <span class="vpi-arrow-left local-search-icon" />
+            </button>
+          </div>
+          <input
+            ref="searchInput"
+            v-model="filterText"
+            :aria-activedescendant="
+              selectedIndex > -1
+                ? 'localsearch-item-' + selectedIndex
+                : undefined
+            "
+            aria-autocomplete="both"
+            :aria-controls="results?.length ? 'localsearch-list' : undefined"
+            aria-labelledby="localsearch-label"
+            autocapitalize="off"
+            autocomplete="off"
+            autocorrect="off"
+            class="search-input"
+            id="localsearch-input"
+            enterkeyhint="go"
+            maxlength="64"
+            :placeholder="translate('button.buttonText')"
+            spellcheck="false"
+            type="search"
+          />
+          <div class="search-actions">
+            <button
+              class="clear-button"
+              type="reset"
+              :disabled="disableReset"
+              :title="translate('modal.resetButtonTitle')"
+              @click="resetSearch"
+            >
+              <span class="vpi-delete local-search-icon" />
+            </button>
+          </div>
+        </form>
+
+        <ul
+          ref="resultsEl"
+          :id="results?.length ? 'localsearch-list' : undefined"
+          :role="results?.length ? 'listbox' : undefined"
+          :aria-labelledby="results?.length ? 'localsearch-label' : undefined"
+          class="results"
+          @mousemove="onMouseMove"
+        >
+          <li
+            v-for="(p, index) in results"
+            :key="p.id"
+            :id="'localsearch-item-' + index"
+            :aria-selected="selectedIndex === index ? 'true' : 'false'"
+            role="option"
+          >
+            <a
+              :href="p.id"
+              class="result"
+              :class="{
+                selected: selectedIndex === index
+              }"
+              :aria-label="[...p.titles, p.title].join(' > ')"
+              @mouseenter="!disableMouseOver && (selectedIndex = index)"
+              @focusin="selectedIndex = index"
+              @click="$emit('close')"
+              :data-index="index"
+            >
+              <div>
+                <div class="titles">
+                  <span class="title-icon">#</span>
+                  <span
+                    v-for="(t, index) in p.titles"
+                    :key="index"
+                    class="title"
+                  >
+                    <span class="text" v-html="t" />
+                    <span class="vpi-chevron-right local-search-icon" />
+                  </span>
+                  <span class="title main">
+                    <span class="text" v-html="p.title" />
+                  </span>
+                </div>
+
+                <div class="excerpt-wrapper">
+                  <div v-if="p.text" class="excerpt" inert>
+                    <div class="vp-doc" v-html="p.text" />
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+          <li
+            v-if="filterText && !results.length && enableNoResults"
+            class="no-results"
+          >
+            {{ translate('modal.noResultsText') }}
+            "<strong>{{ filterText }}</strong
+            >"
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+  .VPLocalSearchBox {
+    position: fixed;
+    z-index: 100;
+    inset: 0;
+    display: flex;
+  }
+
+  .backdrop {
+    position: absolute;
+    inset: 0;
+    background: var(--vp-backdrop-bg-color);
+    transition: opacity 0.5s;
+  }
+
+  .shell {
+    position: relative;
+    padding: 12px;
+    margin: 64px auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    background: var(--vp-local-search-bg);
+    width: min(100vw - 60px, 900px);
+    height: min-content;
+    max-height: min(100vh - 128px, 900px);
+    border-radius: 6px;
+  }
+
+  @media (max-width: 767px) {
+    .shell {
+      margin: 0;
+      width: 100vw;
+      height: 100vh;
+      max-height: none;
+      border-radius: 0;
+    }
+  }
+
+  .search-bar {
+    border: 1px solid var(--vp-c-divider);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    cursor: text;
+  }
+
+  @media (max-width: 767px) {
+    .search-bar {
+      padding: 0 8px;
+    }
+  }
+
+  .search-bar:focus-within {
+    border-color: var(--vp-c-brand-1);
+  }
+
+  .local-search-icon {
+    display: block;
+    font-size: 18px;
+  }
+
+  .navigate-icon {
+    display: block;
+    font-size: 14px;
+  }
+
+  .search-icon {
+    margin: 8px;
+  }
+
+  @media (max-width: 767px) {
+    .search-icon {
+      display: none;
+    }
+  }
+
+  .search-input {
+    padding: 6px 12px;
+    font-size: inherit;
+    width: 100%;
+  }
+
+  .search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  @media (max-width: 767px) {
+    .search-input {
+      padding: 6px 4px;
+    }
+  }
+
+  .search-actions {
+    display: flex;
+    gap: 4px;
+  }
+
+  @media (any-pointer: coarse) {
+    .search-actions {
+      gap: 8px;
+    }
+  }
+
+  @media (min-width: 769px) {
+    .search-actions.before {
+      display: none;
+    }
+  }
+
+  .search-actions button {
+    padding: 8px;
+  }
+
+  .search-actions button:not([disabled]):hover {
+    color: var(--vp-c-brand-1);
+  }
+
+  .search-actions button.clear-button:disabled {
+    opacity: 0.37;
+  }
+
+  .results {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .result {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 4px;
+    transition: none;
+    line-height: 1rem;
+    border: solid 2px var(--vp-local-search-result-border);
+    outline: none;
+  }
+
+  .result > div {
+    margin: 12px;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  @media (max-width: 767px) {
+    .result > div {
+      margin: 8px;
+    }
+  }
+
+  .titles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    position: relative;
+    z-index: 1001;
+    padding: 2px 0;
+  }
+
+  .title {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .title.main {
+    font-weight: 500;
+  }
+
+  .title-icon {
+    opacity: 0.5;
+    font-weight: 500;
+    color: var(--vp-c-brand-1);
+  }
+
+  .title svg {
+    opacity: 0.5;
+  }
+
+  .result.selected {
+    --vp-local-search-result-bg: var(--vp-local-search-result-selected-bg);
+    border-color: var(--vp-local-search-result-selected-border);
+  }
+
+  .excerpt-wrapper {
+    position: relative;
+  }
+
+  .excerpt {
+    opacity: 50%;
+    pointer-events: none;
+    max-height: 140px;
+    overflow: hidden;
+    position: relative;
+    margin-top: 4px;
+  }
+
+  .result.selected .excerpt {
+    opacity: 1;
+  }
+
+  .excerpt :deep(*) {
+    font-size: 0.8rem !important;
+    line-height: 130% !important;
+  }
+
+  .titles :deep(mark),
+  .excerpt :deep(mark) {
+    background-color: var(--vp-local-search-highlight-bg);
+    color: var(--vp-local-search-highlight-text);
+    border-radius: 2px;
+    padding: 0 2px;
+  }
+
+  .excerpt :deep(.vp-code-group) .tabs {
+    display: none;
+  }
+
+  .excerpt :deep(.vp-code-group) div[class*="language-"] {
+    border-radius: 8px !important;
+  }
+
+  .result.selected .titles,
+  .result.selected .title-icon {
+    color: var(--vp-c-brand-1) !important;
+  }
+
+  .no-results {
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 12px;
+  }
+
+  svg {
+    flex: none;
+  }
+</style>

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,0 +1,110 @@
+/* Custom styles for the sh-cmd-tag docs site */
+
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4em;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+}
+
+.breadcrumbs a {
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.breadcrumbs a:hover {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+
+.breadcrumbs-separator {
+  color: var(--vp-c-divider);
+  user-select: none;
+}
+
+.doc-action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.5rem;
+}
+
+.copy-buttons {
+  display: flex;
+  gap: 0.5em;
+}
+
+.inline-copy-btn {
+  display: inline-grid;
+  place-items: center;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  padding: 0.2em 0.5em;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.inline-copy-btn [data-state] {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  visibility: hidden;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+.inline-copy-btn [data-state][aria-hidden="false"] {
+  visibility: visible;
+}
+
+.inline-copy-btn + .inline-copy-btn {
+  margin-left: 0;
+}
+
+.inline-copy-btn:hover {
+  background: var(--vp-c-bg-alt);
+  border-color: var(--vp-c-brand);
+}
+
+.inline-copy-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.inline-copy-btn.copied {
+  background: var(--vp-c-green-soft);
+  border-color: var(--vp-c-green-1);
+  color: var(--vp-c-green-1);
+}
+
+button {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.file-a-bug-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+/*
+ * Local-search excerpts render inside `.vp-doc`, VitePress's full-article
+ * typography, so each excerpt paragraph inherits `p { margin: 16px 0 }` and
+ * pads every result by ~30px of dead space. `CustomSearchBox.vue` already owns
+ * the excerpt's size and clamp (its scoped `.excerpt` rules set `font-size`,
+ * `line-height`, and `max-height`), but its `:deep(*)` selector doesn't touch
+ * the paragraph margins, so strip those here to keep snippets compact
+ * (issue #579).
+ */
+.VPLocalSearchBox .excerpt .vp-doc p {
+  margin: 0;
+}

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,0 +1,8 @@
+import DefaultTheme from "vitepress/theme";
+import CustomLayout from "./CustomLayout.vue";
+import "./custom.css";
+
+export default {
+  extends: DefaultTheme,
+  Layout: CustomLayout,
+};

--- a/.vitepress/url.js
+++ b/.vitepress/url.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import { posix } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** @typedef {import("node:path").ParsedPath} PathDescriptor */
+
+export const DOCS_BASE = "https://chriscalo.github.io/sh-cmd-tag/";
+
+/**
+ * Translate a repo-relative markdown path into its absolute docs-site URL,
+ * matching VitePress `base` + `cleanUrls` (drop `.md`; `SKILL.md`/`index.md`
+ * render at the directory). Any `#anchor` or `?query` is preserved.
+ *
+ * @param {string} relPath e.g. `skills/git/worktrees.md`
+ * @returns {string} absolute URL on the published docs site
+ */
+export function repoPathToUrl(relPath) {
+  // new URL peels #anchor/?query into url.hash/url.search so the transforms
+  // only see the path; url.href reassembles them afterward.
+  const url = new URL(relPath, DOCS_BASE);
+  url.pathname = transformPath(url.pathname);
+  return url.href;
+}
+
+/**
+ * Parse a pathname to a descriptor, run it through each transform, then format
+ * back to a string.
+ *
+ * @type {(pathname: string) => string}
+ */
+const transformPath = pipe(
+  parse,
+  skillToDirectory,
+  indexToDirectory,
+  dropMarkdownExtension,
+  format,
+);
+
+/**
+ * @param {string} path
+ * @returns {PathDescriptor}
+ */
+function parse(path) {
+  return posix.parse(path);
+}
+
+/**
+ * A `SKILL.md` file renders at its bare directory URL (trailing slash).
+ *
+ * @param {PathDescriptor} pathDescriptor
+ * @returns {PathDescriptor}
+ */
+function skillToDirectory(pathDescriptor) {
+  if (pathDescriptor.base === "SKILL.md") {
+    return {
+      ...pathDescriptor,
+      base: "",
+      name: "",
+      ext: "",
+    };
+  } else {
+    return pathDescriptor;
+  }
+}
+
+/**
+ * An `index.md` file renders at its bare directory URL (trailing slash).
+ *
+ * @param {PathDescriptor} pathDescriptor
+ * @returns {PathDescriptor}
+ */
+function indexToDirectory(pathDescriptor) {
+  if (pathDescriptor.base === "index.md") {
+    return {
+      ...pathDescriptor,
+      base: "",
+      name: "",
+      ext: "",
+    };
+  } else {
+    return pathDescriptor;
+  }
+}
+
+/**
+ * Every other `.md` page renders at its path without the extension.
+ *
+ * @param {PathDescriptor} pathDescriptor
+ * @returns {PathDescriptor}
+ */
+function dropMarkdownExtension(pathDescriptor) {
+  if (pathDescriptor.ext === ".md") {
+    return {
+      ...pathDescriptor,
+      base: pathDescriptor.name,
+    };
+  } else {
+    return pathDescriptor;
+  }
+}
+
+/**
+ * @param {PathDescriptor} pathDescriptor
+ * @returns {string}
+ */
+function format(pathDescriptor) {
+  return posix.format(pathDescriptor);
+}
+
+const [, scriptPath, input] = process.argv;
+const __filename = fileURLToPath(import.meta.url);
+
+if (scriptPath === __filename) {
+  main(input);
+}
+
+/**
+ * CLI entry: print the docs-site URL for the given repo-relative path.
+ *
+ * @param {string} input
+ */
+function main(input) {
+  if (!input) {
+    console.error(
+      "Usage: node .vitepress/url.js <repo-relative-path.md>[#anchor]",
+    );
+    process.exit(1);
+  }
+  console.log(repoPathToUrl(input));
+}
+
+/**
+ * Compose transforms left to right. Each receives the running value; a
+ * transform that returns `undefined` leaves the value unchanged.
+ *
+ * @param {...(value: any) => any} transforms
+ * @returns {(value: any) => any}
+ */
+function pipe(...transforms) {
+  return function (value) {
+    for (const transform of transforms) {
+      const result = transform(value);
+      if (result !== undefined) {
+        value = result;
+      }
+    }
+    return value;
+  };
+}

--- a/.vitepress/url.test.js
+++ b/.vitepress/url.test.js
@@ -1,0 +1,49 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { repoPathToUrl } from "./url.js";
+
+const BASE = "https://chriscalo.github.io/sh-cmd-tag/";
+
+describe("repoPathToUrl", () => {
+  test("topic page drops the .md extension", () => {
+    const actual = repoPathToUrl("guide/getting-started.md");
+    const expected = `${BASE}guide/getting-started`;
+    assert.equal(actual, expected);
+  });
+
+  test("index.md renders at the directory URL with a trailing slash", () => {
+    const actual = repoPathToUrl("guide/index.md");
+    const expected = `${BASE}guide/`;
+    assert.equal(actual, expected);
+  });
+
+  test("the root index.md renders at the site root", () => {
+    const actual = repoPathToUrl("index.md");
+    const expected = BASE;
+    assert.equal(actual, expected);
+  });
+
+  test("a #anchor is preserved", () => {
+    const actual = repoPathToUrl("reference/sh.md#safe-mode");
+    const expected = `${BASE}reference/sh#safe-mode`;
+    assert.equal(actual, expected);
+  });
+
+  test("a ?query is preserved", () => {
+    const actual = repoPathToUrl("reference/process.md?plain=1");
+    const expected = `${BASE}reference/process?plain=1`;
+    assert.equal(actual, expected);
+  });
+
+  test("a leading ./ is stripped", () => {
+    const actual = repoPathToUrl("./guide/interpolation.md");
+    const expected = `${BASE}guide/interpolation`;
+    assert.equal(actual, expected);
+  });
+
+  test("a deeply nested topic page keeps its path", () => {
+    const actual = repoPathToUrl("reference/errors/process-error.md");
+    const expected = `${BASE}reference/errors/process-error`;
+    assert.equal(actual, expected);
+  });
+});

--- a/guide/error-handling.md
+++ b/guide/error-handling.md
@@ -1,0 +1,86 @@
+---
+title: "Error Handling"
+---
+
+# Error Handling
+
+You choose how failures are reported: commands can **throw** an exception, or
+they can **return** a result you inspect. By default they throw.
+
+## Throwing behavior (default)
+
+When a command exits with a non-zero code, `sh` and `cmd` reject with a
+[`ProcessError`](/reference/utilities#processerror):
+
+```javascript
+try {
+  await sh`ls /nonexistent/directory`;
+} catch (error) {
+  console.error(error);
+}
+```
+
+The thrown `error` is a `ProcessError` with details about the failure:
+
+```javascript
+{
+  name: "ProcessError",
+  message: "Command failed with exit code 2: ls: cannot access '/nonexistent/directory': No such file or directory",
+  code: 2,
+  output: "",
+  debug: "ls: cannot access '/nonexistent/directory': No such file or directory\n",
+}
+```
+
+- `code` — the process exit code.
+- `output` — anything written to stdout before failing.
+- `debug` — anything written to stderr.
+
+## Non-throwing behavior with `.safe`
+
+Prefix a command with [`.safe`](/reference/sh#safe-mode) to get a
+`ProcessResult` back instead of a thrown error — even when the command fails:
+
+```javascript
+const result = await sh.safe`ls /nonexistent/directory`;
+```
+
+The `result` reports the failure via `ok: false` and includes the same error
+information under `error`:
+
+```javascript
+{
+  ok: false,
+  output: "",
+  debug: "ls: cannot access '/nonexistent/directory': No such file or directory\n",
+  error: {
+    name: "ProcessError",
+    message: "Command failed with exit code 1: ls: cannot access '/nonexistent/directory': No such file or directory",
+    code: 1,
+    output: "",
+    debug: "ls: cannot access '/nonexistent/directory': No such file or directory\n",
+  },
+}
+```
+
+`.safe` is convenient when a non-zero exit is an expected outcome you want to
+branch on rather than an exceptional event:
+
+```javascript
+const result = await sh.safe`grep -q "TODO" src/index.js`;
+if (result.ok) {
+  console.log("Found a TODO");
+} else {
+  console.log("No TODO found");
+}
+```
+
+## Choosing an approach
+
+- Use the **default throwing** behavior when a failure should abort the current
+  flow — it integrates cleanly with `try`/`catch` and `async` error propagation.
+- Use **`.safe`** when a failure is a normal branch in your logic and you'd
+  rather inspect `result.ok` than catch an exception.
+
+See the [`ProcessError` reference](/reference/utilities#processerror) for the
+full shape of the error object.

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -1,0 +1,86 @@
+---
+title: "Getting Started"
+---
+
+# Getting Started
+
+## Installation
+
+`sh-cmd-tag` is published to GitHub Packages. Tell npm where to find the
+`@chriscalo` scope by adding an `.npmrc` file to your project root:
+
+```ini
+@chriscalo:registry=https://npm.pkg.github.com
+```
+
+Then install the package:
+
+```sh
+npm install @chriscalo/sh-cmd-tag
+```
+
+## Your first command
+
+Import the tags and run a command. Every command resolves to a
+[`ProcessResult`](/reference/utilities#processresult):
+
+```javascript
+import { sh, cmd } from "@chriscalo/sh-cmd-tag";
+
+const result = await cmd`echo "Hello World"`;
+```
+
+The resolved `result` is a `ProcessResult` describing the execution:
+
+```javascript
+{
+  ok: true,
+  output: "Hello World\n",
+  debug: "",
+}
+```
+
+- `ok` — whether the command exited successfully.
+- `output` — everything the command wrote to standard output.
+- `debug` — everything the command wrote to standard error.
+
+## Shell execution with `sh`
+
+Use `sh` when you want shell features like pipes, globs, and redirects:
+
+```javascript
+const result = await sh`echo "hello world" | wc -w`;
+```
+
+The shell evaluates the pipe and counts words:
+
+```javascript
+{
+  ok: true,
+  output: "2\n",
+  debug: "",
+}
+```
+
+## Direct execution with `cmd`
+
+Use `cmd` to run a program directly, without a shell. It is faster and does no
+shell parsing, so shell metacharacters are treated as literal text:
+
+```javascript
+const result = await cmd`echo Hello World`;
+console.log(result.output); // "Hello World\n"
+```
+
+::: tip Which one should I use?
+Reach for `cmd` by default — it is faster and avoids the shell entirely. Use
+`sh` only when you specifically need pipes, globs, redirects, or other shell
+behavior.
+:::
+
+## Next steps
+
+- Learn how to safely pass variables in [Interpolation](/guide/interpolation).
+- Understand automatic [Shell Escaping](/guide/shell-escaping).
+- Handle long-running commands with [Streaming Output](/guide/streaming).
+- Deal with failures in [Error Handling](/guide/error-handling).

--- a/guide/index.md
+++ b/guide/index.md
@@ -1,0 +1,36 @@
+---
+title: "Guide"
+---
+
+# Guide
+
+`sh-cmd-tag` provides template tag functions for running shell commands from
+Node.js. This guide walks through everything from your first command to
+streaming output and error handling.
+
+## In this section
+
+- **[Getting Started](/guide/getting-started)** — install the package and run
+  your first `sh` and `cmd` commands.
+- **[Interpolation](/guide/interpolation)** — interpolate strings, objects, and
+  arrays into commands.
+- **[Shell Escaping](/guide/shell-escaping)** — how values are escaped, and how
+  to opt out for trusted input.
+- **[Streaming Output](/guide/streaming)** — process output in real time with
+  the `Process` class.
+- **[Error Handling](/guide/error-handling)** — throwing vs. non-throwing
+  execution and the `ProcessError` shape.
+
+## Two tags: `sh` and `cmd`
+
+The package exposes two primary template tags:
+
+- **`sh`** runs the command through a shell (`/bin/sh`), so pipes, globs,
+  redirects, and other shell features work.
+- **`cmd`** executes a program directly without a shell, which is faster and
+  avoids shell parsing entirely.
+
+Both resolve to a [`ProcessResult`](/reference/utilities#processresult) and both
+support the same interpolation rules and chainable modifiers like
+[`.safe`](/guide/error-handling#safe-mode) and
+[`.sync`](/reference/sh#sync-execution).

--- a/guide/interpolation.md
+++ b/guide/interpolation.md
@@ -1,0 +1,84 @@
+---
+title: "Interpolation"
+---
+
+# Interpolation
+
+Values interpolated into an `sh` or `cmd` template are converted to command-line
+text based on their type. Strings are escaped, objects become flags, and arrays
+become arguments. The same rules apply to both tags.
+
+## Strings
+
+A string is inserted as a single, shell-escaped argument:
+
+```javascript
+const filename = "my file.txt";
+await sh`touch ${filename}`;
+```
+
+The interpolated value is escaped so the space can't split it into two
+arguments. The command that runs is:
+
+```sh
+touch 'my file.txt'
+```
+
+See [Shell Escaping](/guide/shell-escaping) for the full details, including how
+to opt out for trusted input.
+
+## Objects become flags
+
+An object expands into `--key=value` flags. Boolean `true` becomes a bare
+`--flag`, and falsy values are dropped entirely:
+
+```javascript
+const options = { regexp: "error", "ignore-case": true, quiet: false };
+await sh`grep app.log ${options}`;
+```
+
+This produces (note that `quiet: false` is omitted):
+
+```sh
+grep app.log --regexp=error --ignore-case
+```
+
+This is handy for building commands from a config object without manually
+concatenating flags.
+
+## Arrays become arguments
+
+An array expands into multiple space-separated arguments, each escaped
+individually:
+
+```javascript
+const files = ["file1.txt", "file2.txt"];
+await sh`rm ${files}`;
+```
+
+Which becomes:
+
+```sh
+rm file1.txt file2.txt
+```
+
+## Combining interpolations
+
+You can mix interpolation types in a single command:
+
+```javascript
+const flags = { verbose: true };
+const paths = ["src", "test"];
+await sh`eslint ${flags} ${paths}`;
+```
+
+Which becomes:
+
+```sh
+eslint --verbose src test
+```
+
+::: info `sh` vs `cmd`
+Object and array interpolation work identically for `sh` and `cmd`. The only
+difference between the tags is whether the final command runs through a shell.
+:::

--- a/guide/shell-escaping.md
+++ b/guide/shell-escaping.md
@@ -1,0 +1,67 @@
+---
+title: "Shell Escaping"
+---
+
+# Shell Escaping
+
+Every value interpolated into an `sh` or `cmd` template is automatically escaped
+before it reaches the shell. This protects against shell injection: untrusted
+input can't break out of its argument and run arbitrary commands.
+
+## Automatic escaping
+
+Interpolated strings are quoted so their contents stay a single argument, no
+matter what characters they contain:
+
+```javascript
+const userInput = "file with spaces; echo gotcha";
+await sh`cat ${userInput}`;
+```
+
+The dangerous `;` never reaches the shell as a command separator. The command
+safely becomes:
+
+```sh
+cat 'file with spaces; echo gotcha'
+```
+
+Without escaping, `; echo gotcha` would run as a second command. With
+`sh-cmd-tag`, the whole string is treated as one filename.
+
+## Opting out with `markSafeString()`
+
+Sometimes you have trusted input that is *meant* to contain shell syntax — for
+example, a fixed set of flags you control. Wrap it with
+[`markSafeString()`](/reference/utilities#marksafestring) to skip escaping:
+
+```javascript
+import { sh, markSafeString } from "@chriscalo/sh-cmd-tag";
+
+const safeArgs = markSafeString("-la --color=auto");
+await sh`ls ${safeArgs} /home/user`;
+```
+
+No escaping is applied to a marked-safe string, so it becomes:
+
+```sh
+ls -la --color=auto /home/user
+```
+
+::: warning Only mark trusted input
+`markSafeString()` disables the protection that prevents shell injection. Never
+pass user input or any value you don't fully control through it. Use it only for
+constants and values your own code produces.
+:::
+
+## Checking whether a value is marked safe
+
+Use [`isSafeString()`](/reference/utilities#issafestring) to check whether a
+value has been marked safe, and [`shellEscape()`](/reference/utilities#shellescape)
+to escape a value manually when you need the escaped form outside of a template.
+
+## Related
+
+- [Interpolation](/guide/interpolation) — how strings, objects, and arrays are
+  turned into command text.
+- [Utilities reference](/reference/utilities) — the full signatures for
+  `markSafeString`, `isSafeString`, and `shellEscape`.

--- a/guide/streaming.md
+++ b/guide/streaming.md
@@ -1,0 +1,64 @@
+---
+title: "Streaming Output"
+---
+
+# Streaming Output
+
+Awaiting `sh` or `cmd` buffers the entire output and resolves once the command
+finishes. For long-running commands — a build, an install, a watch process —
+you often want to see output *as it happens*. The
+[`Process`](/reference/process) class gives you access to the underlying streams.
+
+## The `Process` class
+
+Create a `Process` with a command string and read from its `output` stream:
+
+```javascript
+import { Process } from "@chriscalo/sh-cmd-tag";
+
+const process = new Process("npm run build");
+process.start();
+
+for await (const chunk of process.output) {
+  console.log("Build output:", chunk.toString());
+}
+```
+
+Each `chunk` arrives as it is produced, so you can display progress, parse
+incremental results, or forward the output somewhere else in real time.
+
+## Available streams
+
+A `Process` exposes the child process's three standard streams:
+
+- **`output`** — standard output (stdout).
+- **`debug`** — standard error (stderr).
+- **`input`** — standard input (stdin), for writing to the process.
+
+```javascript
+const process = new Process("some-long-task");
+process.start();
+
+// Read standard output as it arrives.
+for await (const chunk of process.output) {
+  process.stdout.write(chunk);
+}
+```
+
+## Immediate vs. deferred start
+
+By default a `Process` starts immediately when constructed. Pass
+`{ immediate: false }` to construct it without starting, then call `start()`
+when you're ready:
+
+```javascript
+const process = new Process("npm test", { immediate: false });
+// ...set things up...
+process.start();
+```
+
+Calling `start()` on an already-started process throws, so a process runs at
+most once.
+
+See the [`Process` reference](/reference/process) for the full list of
+properties and configuration options.

--- a/index.js.md
+++ b/index.js.md
@@ -1,0 +1,6 @@
+---
+title: "index.js"
+layout: code-only
+---
+
+<<< @/index.js

--- a/index.md
+++ b/index.md
@@ -1,0 +1,81 @@
+---
+layout: home
+title: sh-cmd-tag
+titleTemplate: Shell command template tags for Node.js
+hero:
+  name: sh-cmd-tag
+  text: Shell commands as template tags
+  tagline: >-
+    Run shell commands from Node.js with template-literal syntax, safe
+    interpolation, streaming output, and flexible I/O control.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: API Reference
+      link: /reference/
+    - theme: alt
+      text: GitHub
+      link: https://github.com/chriscalo/sh-cmd-tag
+features:
+  - icon: 🏷️
+    title: Template literal syntax
+    details: >-
+      Build commands with ordinary template strings. Use sh for full shell
+      expansion or cmd to run a program directly.
+    link: /reference/sh
+  - icon: 🛡️
+    title: Safe interpolation
+    details: >-
+      Interpolated values are shell-escaped automatically, so untrusted input
+      can't break out of an argument.
+    link: /guide/shell-escaping
+  - icon: 🧩
+    title: Objects and arrays
+    details: >-
+      Objects expand into --flag=value pairs and arrays into space-separated
+      arguments — no manual string building.
+    link: /guide/interpolation
+  - icon: 🌊
+    title: Streaming output
+    details: >-
+      Read output as it arrives with the Process class for long-running
+      commands.
+    link: /guide/streaming
+  - icon: 🧯
+    title: Rich error handling
+    details: >-
+      Failures throw a detailed ProcessError, or opt into .safe to get a
+      ProcessResult with ok === false instead.
+    link: /guide/error-handling
+  - icon: ⚡
+    title: Sync and async
+    details: >-
+      Await a command for async execution, or reach for the .sync variant when
+      you need a blocking call.
+    link: /reference/sh
+---
+
+## Quick start
+
+Install from GitHub Packages, then import the tags you need:
+
+```sh
+npm install @chriscalo/sh-cmd-tag
+```
+
+```javascript
+import { sh, cmd } from "@chriscalo/sh-cmd-tag";
+
+// Shell expansion — pipes, globs, redirects
+const words = await sh`echo "hello world" | wc -w`;
+console.log(words.output); // "2\n"
+
+// Direct execution — no shell involved
+const greeting = await cmd`echo Hello World`;
+console.log(greeting.output); // "Hello World\n"
+```
+
+Head to [Getting Started](/guide/getting-started) for a guided tour, or jump
+straight to the [API Reference](/reference/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2395 @@
+{
+  "name": "@chriscalo/sh-cmd-tag",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@chriscalo/sh-cmd-tag",
+      "version": "1.0.0",
+      "devDependencies": {
+        "glob": "^11.0.3",
+        "gray-matter": "^4.0.3",
+        "vitepress": "^2.0.0-alpha.16"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
+      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.6.3.tgz",
+      "integrity": "sha512-qUIX2b4Apew3tv4F0qhmgShsl/Lfw4m6mqv/5/5dWNxwTcDdLMp2s3YwZ+NMGh3IKCg0pBaXm7Q5VdyU5Rj+cQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/sidepanel-js": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/sidepanel-js/-/sidepanel-js-4.6.3.tgz",
+      "integrity": "sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.90",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.90.tgz",
+      "integrity": "sha512-zt2o2ZvQpHVvZJARIkZ51RnaHY2oqcPJMvHE+mVnxkSr+c33fnX4gciiXu+wyX5ei+s0qbVX1wD0DWBbaGBYMA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
+      "integrity": "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
+      "integrity": "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
+      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
+      "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
+      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.3.1.tgz",
+      "integrity": "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.5.tgz",
+      "integrity": "sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^8.1.5"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
+      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^8.1.5",
+        "birpc": "^2.6.1",
+        "hookable": "^5.5.3",
+        "perfect-debounce": "^2.0.0"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
+      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.3.0",
+        "@vueuse/shared": "14.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.3.0.tgz",
+      "integrity": "sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "14.3.0",
+        "@vueuse/shared": "14.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7 || ^8",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7 || ^8",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+      "integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.5.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz",
+      "integrity": "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/engine-javascript": "4.3.1",
+        "@shikijs/engine-oniguruma": "4.3.1",
+        "@shikijs/langs": "4.3.1",
+        "@shikijs/themes": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-Lk1G2/QqSf+MwNLICl9fmzWOtoCEwjZoWgaQy41QvWTfcGpLE9XwJDbcCyES/9rj6R2g1zFqFvLVkYKLLDALFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "^4.6.3",
+        "@docsearch/js": "^4.6.3",
+        "@docsearch/sidepanel-js": "^4.6.3",
+        "@iconify-json/simple-icons": "^1.2.87",
+        "@shikijs/core": "^4.3.0",
+        "@shikijs/transformers": "^4.3.0",
+        "@shikijs/types": "^4.3.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^6.0.7",
+        "@vue/devtools-api": "^8.1.4",
+        "@vue/shared": "^3.5.39",
+        "@vueuse/core": "^14.3.0",
+        "@vueuse/integrations": "^14.3.0",
+        "focus-trap": "^8.2.2",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.2.0",
+        "shiki": "^4.3.0",
+        "vite": "^8.1.3",
+        "vue": "^3.5.39"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
     ".": "./index.js"
   },
   "scripts": {
-    "test": "node --test --no-warnings *.test.js",
-    "test:verbose": "DEBUG=test node --test --no-warnings *.test.js"
+    "test": "node --test --no-warnings *.test.js && node --test --no-warnings .vitepress/*.test.js",
+    "test:verbose": "DEBUG=test node --test --no-warnings *.test.js",
+    "docs:dev": "node scripts/dev.js",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview ."
   },
   "keywords": [
     "shell",
@@ -27,5 +30,13 @@
   },
   "volta": {
     "node": "24.5.0"
+  },
+  "devDependencies": {
+    "glob": "^11.0.3",
+    "gray-matter": "^4.0.3",
+    "vitepress": "^2.0.0-alpha.16"
+  },
+  "overrides": {
+    "esbuild": ">=0.28.1"
   }
 }

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,0 +1,42 @@
+---
+title: "Reference"
+---
+
+# API Reference
+
+Everything `sh-cmd-tag` exports, grouped by area.
+
+## Template tags
+
+- **[`sh` and `cmd`](/reference/sh)** — the two command-execution tags, plus the
+  chainable `.safe`, `.sync`, `.interactive`, and `.input()` modifiers.
+
+## Classes
+
+- **[`Process`](/reference/process)** — encapsulates a child process with
+  streaming `output`, `debug`, and `input` streams.
+
+## Utilities and types
+
+- **[Utilities](/reference/utilities)** — `markSafeString`, `isSafeString`,
+  `shellEscape`, and the `ProcessResult` / `ProcessError` shapes.
+
+## Exports at a glance
+
+```javascript
+import {
+  sh,
+  cmd,
+  Process,
+  ProcessResult,
+  ProcessError,
+  markSafeString,
+  isSafeString,
+  shellEscape,
+} from "@chriscalo/sh-cmd-tag";
+```
+
+## Source
+
+The entire library lives in a single module. You can
+[read the full source](../index.js) — it's rendered right here on the docs site.

--- a/reference/process.md
+++ b/reference/process.md
@@ -1,0 +1,87 @@
+---
+title: "Process"
+---
+
+# `Process`
+
+The `Process` class encapsulates a child process with streaming output and
+enhanced control. Use it when you need to read a command's output as it arrives
+rather than waiting for it to finish. See the [Streaming Output](/guide/streaming)
+guide for a walkthrough.
+
+## Constructor
+
+```javascript
+new Process(commandString, config?)
+```
+
+- **`commandString`** — the command to execute, as a string.
+- **`config`** — optional configuration object.
+
+```javascript
+import { Process } from "@chriscalo/sh-cmd-tag";
+
+const process = new Process("npm run build");
+```
+
+### Configuration
+
+| Option      | Default | Description                                             |
+| ----------- | ------- | ------------------------------------------------------- |
+| `immediate` | `true`  | Start the process as soon as it is constructed.         |
+| `shell`     | `true`  | Run the command through a shell.                        |
+
+Pass `{ immediate: false }` to construct the process without starting it, then
+call [`start()`](#start) yourself:
+
+```javascript
+const process = new Process("npm test", { immediate: false });
+process.start();
+```
+
+## Properties
+
+### `command`
+
+The command string the process was created with.
+
+### `started`
+
+`true` once the process has been started, `false` otherwise.
+
+### `config`
+
+The frozen configuration object in effect for this process.
+
+### `output`
+
+The process's standard output stream (stdout), or `null` before it starts.
+Iterate it to read output as it arrives:
+
+```javascript
+for await (const chunk of process.output) {
+  console.log(chunk.toString());
+}
+```
+
+### `debug`
+
+The process's standard error stream (stderr), or `null` before it starts.
+
+### `input`
+
+The process's standard input stream (stdin), or `null` before it starts. Write
+to it to send input to the command.
+
+## Methods
+
+### `start()`
+
+Starts the process execution. Calling `start()` on a process that has already
+started throws an error, so a process runs at most once:
+
+```javascript
+const process = new Process("echo hi", { immediate: false });
+process.start();
+process.start(); // throws: already been started
+```

--- a/reference/sh.md
+++ b/reference/sh.md
@@ -1,0 +1,116 @@
+---
+title: "sh & cmd"
+---
+
+# `sh` & `cmd`
+
+The two primary template tags. Both build a command from a template literal,
+execute it, and resolve to a [`ProcessResult`](/reference/utilities#processresult).
+
+- **`sh`** runs the command through a shell (`/bin/sh`), enabling pipes, globs,
+  redirects, and other shell features.
+- **`cmd`** executes the program directly, without a shell.
+
+## `sh` — shell execution
+
+```javascript
+const result = await sh`command ${arg}`;
+```
+
+Resolves to a `ProcessResult` after the command completes:
+
+```javascript
+{
+  ok: true,
+  output: "command result\n",
+  debug: "",
+}
+```
+
+## `cmd` — direct execution
+
+```javascript
+const result = await cmd`command ${arg}`;
+```
+
+Resolves to a `ProcessResult` after the command completes:
+
+```javascript
+{
+  ok: true,
+  output: "command output\n",
+  debug: "",
+}
+```
+
+## Interpolation
+
+Both tags apply the same [interpolation rules](/guide/interpolation): strings are
+[shell-escaped](/guide/shell-escaping), objects expand into `--flag=value`
+pairs, and arrays expand into space-separated arguments.
+
+```javascript
+const opts = { verbose: true, output: "file.txt" };
+await sh`command ${opts}`;
+// command --verbose --output=file.txt
+
+const files = ["a.txt", "b.txt"];
+await sh`rm ${files}`;
+// rm a.txt b.txt
+```
+
+## Chainable modifiers
+
+Both `sh` and `cmd` expose chainable properties that change how a command runs.
+Each modifier returns a tag you can call with a template literal.
+
+### Safe mode
+
+`.safe` returns a `ProcessResult` with `ok: false` instead of throwing when the
+command fails. See [Error Handling](/guide/error-handling#non-throwing-behavior-with-safe).
+
+```javascript
+const result = await sh.safe`ls /nonexistent`;
+if (!result.ok) {
+  console.error(result.error);
+}
+```
+
+### Sync execution
+
+`.sync` runs the command synchronously, blocking until it completes, and returns
+the `ProcessResult` directly (no `await`):
+
+```javascript
+const result = sh.sync`echo hello`;
+console.log(result.output); // "hello\n"
+```
+
+`.sync` composes with the other modifiers — for example `sh.sync.safe` runs
+synchronously without throwing.
+
+### Interactive mode
+
+`.interactive` wires the command up to the current process's input, output, and
+debug streams, so it behaves like running the command directly in your terminal:
+
+```javascript
+await sh.interactive`vim notes.txt`;
+```
+
+### Providing input
+
+`.input()` supplies data to the command's standard input:
+
+```javascript
+await sh.input("hello\n")`cat`;
+```
+
+## Async vs. sync summary
+
+| Call            | Returns                      | Blocks? |
+| --------------- | ---------------------------- | ------- |
+| `await sh\`…\`` | `Promise<ProcessResult>`     | No      |
+| `sh.sync\`…\``  | `ProcessResult`              | Yes     |
+
+The same applies to `cmd` and `cmd.sync`.

--- a/reference/utilities.md
+++ b/reference/utilities.md
@@ -1,0 +1,96 @@
+---
+title: "Utilities & Types"
+---
+
+# Utilities & Types
+
+Helper functions for escaping and marking values, plus the shapes of the result
+and error objects.
+
+## Functions
+
+### `markSafeString()`
+
+```javascript
+markSafeString(str)
+```
+
+Marks a string as safe so it is **not** shell-escaped when interpolated into an
+`sh` or `cmd` template. Use it only for trusted input you fully control — see
+the warning in [Shell Escaping](/guide/shell-escaping#opting-out-with-marksafestring).
+
+```javascript
+import { markSafeString } from "@chriscalo/sh-cmd-tag";
+
+const safeArgs = markSafeString("-la --color=auto");
+await sh`ls ${safeArgs}`; // ls -la --color=auto
+```
+
+### `isSafeString()`
+
+```javascript
+isSafeString(value)
+```
+
+Returns `true` if `value` has been marked safe with `markSafeString()`,
+`false` otherwise.
+
+### `shellEscape()`
+
+```javascript
+shellEscape(value)
+```
+
+Returns the shell-escaped form of `value`. This is the same escaping applied
+automatically during interpolation, exposed for when you need the escaped string
+directly.
+
+```javascript
+import { shellEscape } from "@chriscalo/sh-cmd-tag";
+
+shellEscape("my file.txt"); // "'my file.txt'"
+```
+
+## Types
+
+### `ProcessResult`
+
+The object every command resolves to. Describes the outcome of an execution.
+
+| Field    | Type      | Description                                             |
+| -------- | --------- | ------------------------------------------------------- |
+| `ok`     | `boolean` | Whether the command exited successfully.                |
+| `output` | `string`  | Everything written to standard output.                  |
+| `debug`  | `string`  | Everything written to standard error.                   |
+| `error`  | `ProcessError` | Present on `.safe` results when the command failed. |
+
+```javascript
+{
+  ok: true,
+  output: "Hello World\n",
+  debug: "",
+}
+```
+
+### `ProcessError`
+
+Thrown when a command fails (or attached as `result.error` under
+[`.safe`](/guide/error-handling#non-throwing-behavior-with-safe)).
+
+| Field     | Type     | Description                                     |
+| --------- | -------- | ----------------------------------------------- |
+| `name`    | `string` | Always `"ProcessError"`.                        |
+| `message` | `string` | Human-readable summary including the exit code. |
+| `code`    | `number` | The process exit code.                          |
+| `output`  | `string` | Anything written to stdout before failing.      |
+| `debug`   | `string` | Anything written to stderr.                     |
+
+```javascript
+{
+  name: "ProcessError",
+  message: "Command failed with exit code 2: ...",
+  code: 2,
+  output: "",
+  debug: "ls: cannot access '/nonexistent': No such file or directory\n",
+}
+```

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * =============================================================================
+ * dev.js — Development server with hot-reload for skills documentation
+ * =============================================================================
+ *
+ * DESCRIPTION
+ *   Starts the VitePress development server and watches for changes in the
+ *   skills/ directory. When skill files change, it triggers a VitePress
+ *   reload by touching the config file, which causes the sidebar to update.
+ *
+ * USAGE
+ *   node scripts/dev.js
+ *   # Or via npm:
+ *   npm run dev
+ *
+ * BEHAVIOR
+ *   - Spawns VitePress dev server as a child process
+ *   - Watches skills/ directory recursively for any file changes
+ *   - On change, touches .vitepress/config.js to trigger sidebar regeneration
+ *   - Handles SIGINT (Ctrl+C) gracefully, cleaning up watchers and child process
+ *
+ * REQUIREMENTS
+ *   - Node.js with ES modules support
+ *   - VitePress installed in the project
+ *
+ * =============================================================================
+ */
+import { spawn } from "child_process";
+import { watch, utimesSync, existsSync } from "fs";
+
+/** Path to VitePress config file — touched to trigger hot reload */
+const CONFIG_PATH = ".vitepress/config.js";
+
+/**
+ * Start VitePress development server.
+ * - Uses npx to run vitepress from node_modules
+ * - Inherits stdio so output appears in the current terminal
+ * - Runs in shell mode for cross-platform compatibility
+ */
+const vitepress = spawn("npx vitepress dev .", {
+  stdio: "inherit",
+  shell: true,
+});
+
+/**
+ * Watch the content directories for file changes.
+ * When any markdown file changes (add, modify, delete), we "touch" the
+ * VitePress config file, which triggers VitePress to regenerate the nav and
+ * sidebar with any new or removed pages.
+ */
+const WATCH_DIRS = ["guide", "reference"];
+const watchers = WATCH_DIRS
+  .filter((dir) => existsSync(dir))
+  .map((dir) =>
+    watch(dir, { recursive: true }, (event, filename) => {
+      const now = new Date();
+      utimesSync(CONFIG_PATH, now, now);
+      console.log(`\n[dev] ${event}: ${dir}/${filename} — reloading nav\n`);
+    }),
+  );
+
+/**
+ * Handle graceful shutdown on Ctrl+C.
+ * Closes the file watchers and terminates the VitePress child process
+ * before exiting cleanly.
+ */
+process.on("SIGINT", () => {
+  for (const watcher of watchers) watcher.close();
+  vitepress.kill();
+  process.exit(0);
+});


### PR DESCRIPTION
Closes #23.

Builds a documentation site for `sh-cmd-tag`, applying the `/web` VitePress
skills from https://chriscalo.github.io/dev-skills/skills/web/vitepress/.

## Skills applied
- **Auto Nav** — `nav`/`sidebar` generated from the file system
  (`.vitepress/nav.js`), with a coverage test (`.vitepress/nav.test.js`)
  asserting the nav matches the canonical indexed-page set in both directions,
  cross-checked against `repoPathToUrl`.
- **Homepage Hero** — `index.md` uses the `home` layout with hero, action
  buttons, and feature cards.
- **Copy Buttons** & **File a Bug** — per-page Copy Link / Copy Markdown / File
  a Bug buttons via a custom layout + `transformPageData`.
- **Breadcrumbs** — build-time trail above each page title from ancestor dirs.
- **Linked Assets** — a relative link to `index.js` resolves to a
  syntax-highlighted viewer page plus an `index.js.raw` plain-text URL.
- **Search** — local search tuned for code (AND matching, camelCase/path
  tokenization, one result per page, best-match excerpts) via the forked
  search box.

## Content
Guide (getting started, interpolation, shell escaping, streaming, error
handling) and an API reference (`sh`/`cmd`, `Process`, utilities & types).

## Tooling
- `docs:dev` / `docs:build` / `docs:preview` scripts and build devDependencies.
- GitHub Pages deploy workflow (`.github/workflows/publish-to-github-pages.yaml`).

## Verification
- `npm test` — all suites pass (root + `.vitepress` url/nav tests).
- `npm run docs:build` — builds clean; VitePress dead-link checker passes with
  no `ignoreDeadLinks` override.
- Previewed locally: home, guide, reference, code viewer, and `.raw` asset all
  serve `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)